### PR TITLE
Add CMakeLists.txt file and fix missing include<string>

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,47 @@
+cmake_minimum_required(VERSION 3.5)
+
+project(CppDesignPatterns)
+
+set(PATTERNS
+    abstract-factory
+    adapter
+    bridge
+    builder
+    chain-of-responsibility
+    command
+    composite
+    decorator
+    facade
+    factory-method
+    flyweight
+    interpreter
+    iterator
+    mediator
+    memento
+    observer
+    prototype
+    proxy
+    singleton
+    state
+    strategy
+    template-method
+    visitor
+)
+
+foreach(_dir IN ITEMS ${PATTERNS})
+    file(GLOB _files "${_dir}/*.cpp")
+    message(STATUS "Pattern `${_dir}':")
+
+    foreach(_file IN ITEMS ${_files})
+
+        get_filename_component(_file_name
+                                ${_file} NAME
+        )
+
+        set(_project_name "${_file_name}")
+        message(STATUS "  ${_dir}/${_file_name} is going to be built")
+        
+        add_executable(${_project_name} "${_dir}/${_file_name}")
+    endforeach()
+    
+endforeach()

--- a/builder/Builder.cpp
+++ b/builder/Builder.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <iostream>
+#include <string>
 
 /*
  * Product

--- a/factory-method/FactoryMethod.cpp
+++ b/factory-method/FactoryMethod.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <iostream>
+#include <string>
 
 /*
  * Product

--- a/mediator/Mediator.cpp
+++ b/mediator/Mediator.cpp
@@ -10,6 +10,7 @@
 
 #include <iostream>
 #include <vector>
+#include <string>
 
 class Mediator;
 

--- a/prototype/Prototype.cpp
+++ b/prototype/Prototype.cpp
@@ -9,6 +9,7 @@
  */
 
 #include <iostream>
+#include <string>
 
 /*
  * Prototype


### PR DESCRIPTION
So `CMakeLists.txt` makes people feel convenient to build all these source codes, tested under Windows (MSVC) and Ubuntu (gcc).
However, some compile errors occur in MSVC just because of the missing `include<string>`, so I also add them to finish building.
Thanks for the project. Hope you have a good day.